### PR TITLE
Revert "Bump eslint-plugin-vue from 5.2.2 to 5.2.3"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5922,9 +5922,9 @@
       "dev": true
     },
     "eslint-plugin-vue": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-5.2.3.tgz",
-      "integrity": "sha512-mGwMqbbJf0+VvpGR5Lllq0PMxvTdrZ/ZPjmhkacrCHbubJeJOt+T6E3HUzAifa2Mxi7RSdJfC9HFpOeSYVMMIw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-5.2.2.tgz",
+      "integrity": "sha512-CtGWH7IB0DA6BZOwcV9w9q3Ri6Yuo8qMjx05SmOGJ6X6E0Yo3y9E/gQ5tuNxg2dEt30tRnBoFTbvtmW9iEoyHA==",
       "dev": true,
       "requires": {
         "vue-eslint-parser": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-promise": ">=4.1.1",
     "eslint-plugin-standard": ">=4.0.0",
-    "eslint-plugin-vue": "^5.2.3",
+    "eslint-plugin-vue": "^5.2.2",
     "less": "^3.9.0",
     "less-loader": "^5.0.0",
     "node-sass": "^4.12.0",


### PR DESCRIPTION
This reverts commit 5768c0aec64c08f73dbaed56492c03e0e01bfce5.